### PR TITLE
Issue-661 , Migrate store pets geo location endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .gradle
 .idea/
 /build
+/bin
+.vscode

--- a/src/main/java/com/josdem/vetlog/command/PetLocationCommand.java
+++ b/src/main/java/com/josdem/vetlog/command/PetLocationCommand.java
@@ -1,0 +1,23 @@
+/*
+  Copyright 2025 Jose Morales contact@josdem.io
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.josdem.vetlog.command;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PetLocationCommand(
+    @NotNull(message = "Pets Ids cannot be null")
+    Iterable<Long> petsIds) implements Command {}

--- a/src/main/java/com/josdem/vetlog/controller/PetLocationController.java
+++ b/src/main/java/com/josdem/vetlog/controller/PetLocationController.java
@@ -1,0 +1,63 @@
+/*
+  Copyright 2025 Jose Morales contact@josdem.io
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.josdem.vetlog.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.josdem.vetlog.command.PetLocationCommand;
+import com.josdem.vetlog.model.Location;
+import com.josdem.vetlog.repository.LocationRepository;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/geolocation")
+public class PetLocationController{
+
+    @Value("${app.domain}")
+    private String domain;
+
+    private final LocationRepository locationRepository;
+    public PetLocationController(LocationRepository locationRepository){
+        this.locationRepository = locationRepository;    
+    }
+
+    @PostMapping("/storePetLocation")
+    public ResponseEntity<String> storePets(
+                                            @Valid @RequestBody PetLocationCommand pets ,
+                                            HttpServletResponse response){
+                                              
+      log.info("Storing pets: {}", pets.toString());
+      response.addHeader("Access-Control-Allow-Methods", "POST");
+      response.addHeader("Access-Control-Allow-Origin", domain);
+
+      pets.petsIds().forEach(id -> {
+          locationRepository.save(id, new Location(0.00 , 0.00)); 
+      });
+
+      return new ResponseEntity<>("Created new pets", HttpStatus.CREATED);
+    } 
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,8 @@
 spring.application.name=vetlog-backend
 geoToken=userToken
 app.domain=vetlog.org
+
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password

--- a/src/test/java/com/josdem/vetlog/controller/PetLocationControllerTest.kt
+++ b/src/test/java/com/josdem/vetlog/controller/PetLocationControllerTest.kt
@@ -1,0 +1,73 @@
+
+/*
+  Copyright 2025 Jose Morales contact@josdem.io
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.josdem.vetlog.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.josdem.vetlog.command.LocationRequestCommand
+import com.josdem.vetlog.command.PetLocationCommand;
+import com.josdem.vetlog.repository.LocationRepository
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.junit.jupiter.api.Assertions.assertEquals
+import com.josdem.vetlog.model.Location;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PetsLocationControllerTest {
+   
+  @Autowired
+  private lateinit var mockMvc: MockMvc
+
+  @Autowired
+  private lateinit var objectMapper: ObjectMapper
+  
+  private lateinit var locationRepository: LocationRepository
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @Test 
+  fun `should store pets ids and relative locations`(testInfo: TestInfo){
+    val petLocationCommand = PetLocationCommand(listOf(1L, 2L, 3L))
+    locationRepository = LocationRepository()
+    locationRepository.save(1L,Location(0.0,0.0))
+    locationRepository.save(2L,Location(0.0,0.0))
+    locationRepository.save(3L,Location(0.0,0.0))
+
+    mockMvc
+      .perform(
+        post("/geolocation/storePetLocation")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(petLocationCommand))
+    ).andExpect(status().isCreated())
+    
+    assertEquals(3,locationRepository.findAll().size)
+  }
+}


### PR DESCRIPTION
From vetlog-spring-boot issue 661 , Migrate store pets geo location endpoint.
I have done the following : 
- Created a new RestController 
- Create a new PostMagging end-point named storePets
- I have a ConcurrentHashMap to store pets in memory
- I have test written in Kotlin 
- All tests are pasisng 

Please give feedback on how I should improve.
Also I don't know if the tests are appropriate .