### PR TITLE
Add Spotless plugin for automatic code formatting via Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 	id("org.jetbrains.kotlin.jvm") version "2.2.0"
 	jacoco
 	id("org.sonarqube") version "6.2.0.5505"
+	id("com.diffplug.spotless") version "6.25.0"
 }
 
 group = "com.josdem.vetlog"
@@ -108,5 +109,25 @@ sonar {
 
 		// Test and coverage reports
 		property("sonar.junit.reportPaths", "build/test-results/test")
+	}
+}
+
+// Spotless Configuration
+spotless {
+	java {
+		target("src/**/*.java")
+		googleJavaFormat("1.17.0")
+		importOrder()
+	}
+
+	kotlin {
+		target("src/**/*.kt")
+		ktfmt("0.44")
+	}
+
+	format("misc") {
+		target("*.gradle.kts", "*.md", "*.gitignore")
+		trimTrailingWhitespace()
+		endWithNewline()
 	}
 }


### PR DESCRIPTION
This PR adds the Spotless plugin to the Gradle build, allowing automatic code formatting from the command line and integration with Gradle.

- Configures Spotless for Java files
- Can run `./gradlew spotlessCheck` to verify formatting
- Can run `./gradlew spotlessApply` to fix violations

This addresses issue #36 