### PR TITLE
feat(config): externalize YAML properties via spring.config.location

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,3 +147,9 @@ tasks.withType<Test> {
 springBoot {
     buildInfo()
 }
+
+tasks.bootRun {
+    doFirst {
+        systemProperties = System.getProperties().mapKeys { it.key.toString() }
+    }
+}


### PR DESCRIPTION
Fixed : #55

Added support for external YAML configuration using:
  -Dspring.config.location=$HOME/.vetlog_backend/application-development.yml
  
Updated bootRun to forward JVM system properties so Spring Boot receives external config.
All existing tests remain passing.